### PR TITLE
feat(sync): extract index generation to OnThisDayIndexWorkflow

### DIFF
--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -7,6 +7,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { eq } from "drizzle-orm";
 import { pages as pagesTable } from "@jigsaw/db";
 export { OnThisDayWorkflow } from "./on-this-day";
+export { OnThisDayIndexWorkflow } from "./on-this-day-index";
 
 type Env = {
   R2: R2Bucket;
@@ -14,6 +15,7 @@ type Env = {
   SYNC_WORKFLOW: Workflow;
   SYNC_BATCH_WORKFLOW: Workflow;
   ON_THIS_DAY_WORKFLOW: Workflow;
+  ON_THIS_DAY_INDEX_WORKFLOW: Workflow;
 };
 
 type ScrapboxListResponse = {

--- a/packages/sync/src/on-this-day-index.ts
+++ b/packages/sync/src/on-this-day-index.ts
@@ -1,0 +1,72 @@
+import {
+  WorkflowEntrypoint,
+  WorkflowEvent,
+  WorkflowStep,
+} from "cloudflare:workers";
+import { drizzle } from "drizzle-orm/d1";
+import { eq } from "drizzle-orm";
+import { pages, onThisDayEntries } from "@jigsaw/db";
+
+type Env = {
+  R2: R2Bucket;
+  DB: D1Database;
+};
+
+export class OnThisDayIndexWorkflow extends WorkflowEntrypoint<Env, {}> {
+  async run(event: WorkflowEvent<{}>, step: WorkflowStep) {
+    const runId = Date.now();
+    console.log(`[OnThisDayIndex] START: runId=${runId}`);
+
+    const db = drizzle(this.env.DB);
+
+    const counts = await step.do(`generate-index-${runId}`, async () => {
+      const allEntries = await db
+        .select({
+          year: onThisDayEntries.year,
+          mmdd: pages.title,
+        })
+        .from(onThisDayEntries)
+        .innerJoin(pages, eq(onThisDayEntries.pageID, pages.id));
+
+      const yearSet = new Set<number>();
+      const tempIndex: Record<string, Record<number, number>> = {};
+
+      for (const entry of allEntries) {
+        yearSet.add(entry.year);
+        if (!tempIndex[entry.mmdd]) {
+          tempIndex[entry.mmdd] = {};
+        }
+        const yearCounts = tempIndex[entry.mmdd];
+        yearCounts[entry.year] = (yearCounts[entry.year] || 0) + 1;
+      }
+
+      const years = Array.from(yearSet).sort((a, b) => a - b);
+      const yearMap = new Map(years.map((y, i) => [y, i]));
+
+      const entries: Record<string, [number, number][]> = {};
+      for (const [mmdd, counts] of Object.entries(tempIndex)) {
+        entries[mmdd] = Object.entries(counts).map(([year, count]) => [
+          yearMap.get(parseInt(year, 10))!,
+          count,
+        ]);
+        // Sort by year index for consistency
+        entries[mmdd].sort((a, b) => a[0] - b[0]);
+      }
+
+      const result = {
+        years,
+        entries,
+      };
+
+      await this.env.R2.put("on-this-day-index.json", JSON.stringify(result));
+
+      return {
+        dayCount: Object.keys(entries).length,
+        entryCount: allEntries.length,
+      };
+    });
+
+    console.log(`[OnThisDayIndex] FINISH: runId=${runId}, dayCount=${counts.dayCount}, entryCount=${counts.entryCount}`);
+    return counts;
+  }
+}

--- a/packages/sync/src/on-this-day.ts
+++ b/packages/sync/src/on-this-day.ts
@@ -11,6 +11,7 @@ import { parse, type Node } from "@progfay/scrapbox-parser";
 type Env = {
   R2: R2Bucket;
   DB: D1Database;
+  ON_THIS_DAY_INDEX_WORKFLOW: Workflow;
 };
 
 type OnThisDayParams = {
@@ -40,7 +41,7 @@ export class OnThisDayWorkflow extends WorkflowEntrypoint<
     const { cutoff: payloadCutoff, fullScan, start, end } = event.payload ?? {};
     let cutoff = payloadCutoff;
 
-    if (fullScan) {
+    if (fullScan || start || end) {
       cutoff = 0;
     } else if (cutoff === undefined) {
       cutoff = Math.floor(Date.now() / 1000) - 25 * 60 * 60;

--- a/packages/sync/wrangler.jsonc
+++ b/packages/sync/wrangler.jsonc
@@ -21,6 +21,11 @@
       "name": "on-this-day-workflow",
       "binding": "ON_THIS_DAY_WORKFLOW",
       "class_name": "OnThisDayWorkflow"
+    },
+    {
+      "name": "on-this-day-index-workflow",
+      "binding": "ON_THIS_DAY_INDEX_WORKFLOW",
+      "class_name": "OnThisDayIndexWorkflow"
     }
   ],
   "r2_buckets": [


### PR DESCRIPTION
Moved the index generation logic from OnThisDayWorkflow to a dedicated OnThisDayIndexWorkflow.

This allows for better separation of concerns and independent execution.

Also optimized the index JSON format and added return values for monitoring.