### PR TITLE
chore: add renovate config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ dist
 .jj
 pnpm-lock.yaml
 *.log
+*.json

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "schedule": ["before 6am on monday"],
+  "timezone": "Asia/Tokyo",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 10,
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": false
+    },
+    {
+      "groupName": "cloudflare",
+      "matchPackageNames": ["wrangler", "@cloudflare/**"]
+    },
+    {
+      "groupName": "drizzle",
+      "matchPackageNames": ["drizzle-orm", "drizzle-kit"]
+    },
+    {
+      "groupName": "react",
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"]
+    },
+    {
+      "groupName": "vike",
+      "matchPackageNames": ["vike", "vike-**", "@photonjs/**"]
+    },
+    {
+      "groupName": "three",
+      "matchPackageNames": ["three", "@react-three/**", "@types/three"]
+    },
+    {
+      "groupName": "tailwindcss",
+      "matchPackageNames": ["tailwindcss", "@tailwindcss/**", "postcss", "autoprefixer"]
+    },
+    {
+      "groupName": "vite",
+      "matchPackageNames": ["vite", "@vitejs/**", "vite-**", "vitest"]
+    },
+    {
+      "groupName": "hono",
+      "matchPackageNames": ["hono"]
+    },
+    {
+      "groupName": "og-image",
+      "matchPackageNames": ["satori", "@resvg/**"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Dependabot の代わりに Renovate を導入。`renovate.json` を追加。

## 設定内容
- **schedule**: 毎週月曜の朝6時前 (Asia/Tokyo)
- **prConcurrentLimit**: 10
- **lockFileMaintenance**: 有効 (週次で lockfile リフレッシュ)
- **groups**: 旧 dependabot.yml と同じ粒度で cloudflare / drizzle / react / vike / three / tailwindcss / vite / hono / og-image を分けてる
- **dependencyDashboard**: 有効 (Issue で全更新を一覧管理)
- pnpm catalog はネイティブサポートなので追加設定不要

## 必要な手順
このマージ後、Renovate GitHub App を https://github.com/apps/renovate からインストールして jgsme/jgs.me を有効化する必要あり。